### PR TITLE
Update v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 &nbsp;
 
-#### *v3.5.0 - 03/10/2018
+#### *v3.6.0 - /10/2018
+
+ - Added support for importing entie directories. Using this methods, the files are not compiled in any specific order;
+ - Fixed a bug in the github imports. Starting with a line broke the fileDownloader.js ('/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js' / 'twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js').
+
+&nbsp;
+
+#### v3.5.0 - 03/10/2018
 
  - Major update to the parseImports.js module:
    * **Added support for making file imports from an URL and GitHub repositories (read more in README.md)**;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 &nbsp;
 
-#### *v3.6.0 - /10/2018
+#### *v3.6.0 - 04/10/2018
 
- - Added support for importing entie directories. Using this methods, the files are not compiled in any specific order;
- - Fixed a bug in the github imports. Starting with a line broke the fileDownloader.js ('/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js' / 'twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js').
+ - **Added support for importing entie directories. Using this methods, the files are not compiled in any specific order**;
+ - Fixed a bug introduced in v3.5.0 (commit: https://github.com/joao-neves95/merger-js/commit/815e2f16ed62f13fd82f1d3d96362d3664b64249#diff-e8f6b017cf5303324df391ba7f9e0b07), in the auto build 'chnage' event async Callback (called multiple times);
+ - Fixed a bug in the github imports. Starting the path of the github repository with a bar broke the fileDownloader.js ('/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js' vs. 'twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js');
+ - Minor optimization and fixes on the parseImports.js module.
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
  - [x] **Minification, supporting ES6+** (optional)
  - [x] **Auto builds on files changes** (optional)
  - [x] **Native OS build notifications** (optional)
+ - [x] **Import a directory** (use ```@import<<DIR 'directoryName/'```)
  - [x] **Import a file from the node_modules folder** (use ```$import 'file-name'```)
  - [x] **Import a file from an URL** (use ```%import 'url'```)
  
@@ -77,7 +78,8 @@ npm install merger-js -g
    // %import 'https://cdnjs.cloudflare.com/ajax/libs/react/16.4.2/cjs/react.development.js'
    // %<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'
    // @'externalLibs'
-   // @import'utilities'
+   // @import<<dir '/enums/'
+   // @import 'utilities'
    // @import 'someModel'
    // @import 'someView'
    // @import 'someController'
@@ -138,7 +140,10 @@ npm install merger-js -g
 ## Import Syntax:
 
 - ```// @import 'relativePathToTheFile'``` or ```// @'relativePathToTheFile'```:<br/>
-   Using an ```@``` token on an import statement imports a file relative to the header file.
+   Using an ```@``` token on an import statement imports a file relative to the header file.<br/>
+
+  * Pushing (```<<```) ```dir```, ```DIR```, ```directory``` or ```DIRECTORY``` into ```@import```, imports an entire directory. Using this method, the files are not compiled in any specific order.<br/>
+    E.g.: ``` // @import<<dir '../otherDirectory/'``` ```// @<<DIR 'someDirectoryHere/'```
 
 - ```// $import 'pathRelativeToNodeModules'``` or ```// $'node_modules_file'```:<br/>
    Using a ```$``` token imports relative to the "node_modules" directory.
@@ -148,7 +153,7 @@ npm install merger-js -g
   If the branch name is not provided, it defaults to the "master" branch.
 
   * Pushing (```<<```) ```GH```, ```gh```, ```github``` or ```GITHUB``` into ```%import```, imports a file from a GitHub repository.<br/>
-    E.g: ```// %import<<GH '<userName>/<repositoryName>/<branchName>/<pathToFile>'```<br/>
+    E.g.: ```// %import<<GH '<userName>/<repositoryName>/<branchName>/<pathToFile>'```<br/>
          ```// $<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'```
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
 # TODO
 
-- Add support for importing entire directories (without any specific order);
-
-- Fix the github imports. Bug with the bars ('/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js' / 'twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js');
+- Solve bug in the auto build async Callback() (calling multiple times);
 
 - Solve bug where its added "\ufeff" unicode characters on the build/read files process. No interpreter errors though (Char encoding Node.js issue. Use "strip-bom" package on the next release);
 
@@ -13,6 +11,4 @@
 --------------------------------------------------------------------------------------------------------------------------
 ### Proposals:
 
-- Add the import directory sintax: 
-  * ``` @import<<dir './someDirRelativeToThisFile' ``` or ``` // @<<dir '../models' ```.
 --------------------------------------------------------------------------------------------------------------------------

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 # TODO
 
-- Solve bug in the auto build async Callback() (calling multiple times);
-
 - Solve bug where its added "\ufeff" unicode characters on the build/read files process. No interpreter errors though (Char encoding Node.js issue. Use "strip-bom" package on the next release);
 
 - TESTS;

--- a/merger.js
+++ b/merger.js
@@ -1,19 +1,21 @@
 #!/usr/bin/env node
-'use strict'
+'use strict';
 const path = require('path');
 const chokidar = require('chokidar');
 const mergerCLI = require('./modules/mergerCLI');
 const config = require('./modules/config');
-const selectSourceFile = require('./modules/CLIModules/selectSourceFilePrompt');
 const async = require( './node_modules/neo-async' );
+const selectSourceFile = require('./modules/CLIModules/selectSourceFilePrompt');
 const parseImports = require( './modules/buildModules/parseImports' );
-const build = require('./modules/buildModules/build');
+const build = require( './modules/buildModules/build' );
+const sourceFileModel = require( './models/sourceFileModel' );
 
 // PROGRAM:
 mergerCLI((newConfig) => {
   config( newConfig, () => {
 
-    selectSourceFile((sourceFile) => {
+    selectSourceFile( ( sourceFile ) => {
+      /** @type { sourceFileModel[] } */
       let files = [sourceFile];
 
       // If "sourceFile" is Array it means that the user chose the "All" (files) option in selectSourceFile().
@@ -22,14 +24,15 @@ mergerCLI((newConfig) => {
         // Execute a one time build only.
         global.config.autoBuild = false;
       }
-      
+
+      // TODO: BUG with Callback. Can not call multiple times (autoBuild).
       async.eachSeries( files, ( file, Callback ) => {
 
         parseImports( file.source, async ( buildOrder ) => {
           // Execute one time builds:
           if ( !global.config.autoBuild ) {
             await build( file, buildOrder );
-            Callback();
+            return Callback();
           }
 
           // Execute an auto builds (with file watcher):
@@ -38,18 +41,17 @@ mergerCLI((newConfig) => {
 
             whatcher
               .on( 'ready', async () => {
-                console.info(' Inicial scan complete. Ready to build on changes...');
+                console.info( ' Inicial scan complete. Ready to build on changes...' );
                 await build( file, buildOrder );
-                Callback();
+                return Callback();
               })
               .on('error', err => console.error('Auto build error: ', err))
               .on( 'change', async ( path, stats ) => {
                 await build(file, null);
-                Callback();
+                return Callback();
             });
           }
         });
-
 
       }, (err) => {
           if (err) throw err;

--- a/merger.js
+++ b/merger.js
@@ -10,7 +10,8 @@ const parseImports = require( './modules/buildModules/parseImports' );
 const build = require( './modules/buildModules/build' );
 const sourceFileModel = require( './models/sourceFileModel' );
 
-// PROGRAM:
+// #region PROGRAM
+
 mergerCLI((newConfig) => {
   config( newConfig, () => {
 
@@ -48,7 +49,6 @@ mergerCLI((newConfig) => {
               .on('error', err => console.error('Auto build error: ', err))
               .on( 'change', async ( path, stats ) => {
                 await build(file, null);
-                return Callback();
             });
           }
         });
@@ -59,5 +59,6 @@ mergerCLI((newConfig) => {
 
     });
   });
-});
-// End of PROGRAM.
+} );
+
+// #endregion

--- a/modules/CLIModules/selectSourceFilePrompt.js
+++ b/modules/CLIModules/selectSourceFilePrompt.js
@@ -3,6 +3,7 @@ const path = require('path');
 const prompt = require('../../node_modules/inquirer').createPromptModule();
 const readDir = require('../utils').readDir;
 const findFile = require( '../utils' ).findFileOrDir;
+const sourceFileModel = require( '../../models/sourceFileModel' );
 const style = require('../consoleStyling');
 
 const question = [

--- a/modules/buildModules/build.js
+++ b/modules/buildModules/build.js
@@ -29,6 +29,7 @@ const build = ( sourceFile, buildOrder ) => {
         allData[file] = data;
         Callback();
       } );
+
     }, ( err ) => {
       if ( err ) {
         console.error( style.styledError, err );

--- a/modules/buildModules/parseImports.js
+++ b/modules/buildModules/parseImports.js
@@ -29,8 +29,13 @@ module.exports = ( Path, Callback ) => {
     if ( treatedLine.startsWith( '@import', 2 ) || treatedLine.startsWith( '@', 2 ) ) {
       treatedLine = Utils.removeImportFromInput( treatedLine );
 
-      if ( treatedLine.startsWith( '<<dir' ) || treatedLine.startsWith( '<<DIR' ) || treatedLine.startsWith( '<<directory' ) ) {
-        treatedLine = treatedLine.replace( /<<dir|<<directory/g, '' );
+      // FROM A DIRECTORY.
+      if ( treatedLine.startsWith( '<<dir' ) ||
+           treatedLine.startsWith( '<<DIR' ) ||
+           treatedLine.startsWith( '<<directory' ) ||
+           treatedLine.startsWith( '<<DIRECTORY' ) ) {
+
+        treatedLine = treatedLine.replace( /<<dir|<<DIR|<<directory|<<DIRECTORY/g, '' );
         // Build the path.
         treatedLine = Utils.cleanImportFileInput( treatedLine );
         const thisDir = path.join( path.dirname( Path ), treatedLine );
@@ -48,6 +53,7 @@ module.exports = ( Path, Callback ) => {
           return console.error( style.styledError, `There was an error while reading the file names from the directory: "${treatedLine}"\n`, err );
         }
 
+      // FROM A RELATIVE FILE PATH.
       } else {
         thisFile = cleanImportFileInput( treatedLine );
       }
@@ -89,7 +95,7 @@ module.exports = ( Path, Callback ) => {
       if ( treatedLine.startsWith( '<<gh' ) ||
            treatedLine.startsWith( '<<GH' ) ||
            treatedLine.startsWith( '<<github' ) ||
-        treatedLine.startsWith( '<<GITHUB' ) ) {
+           treatedLine.startsWith( '<<GITHUB' ) ) {
 
         let filePath = cleanImportFileInput( treatedLine );
         filePath = filePath.replace( /<<gh|<<GH|<<github|<<GITHUB/g, '' );

--- a/modules/fileDownloader.js
+++ b/modules/fileDownloader.js
@@ -48,20 +48,22 @@ module.exports = {
    * @returns { Promise<string | Error> }
    */
   fromGitHub: ( path, Callback ) => {
-    return new Promise( ( resolve, reject ) => {
+    return new Promise( async ( resolve, reject ) => {
 
-      ( async () => {
-        let url = HOST_RAW_GITHUB + path;
-        const fileName = Utils.getFileNameFromUrl( url );
-        let fileContent = null;
+      if ( path.startsWith( '/' ) )
+        path = path.substring( 1 );
 
-        try {
+      let url = HOST_RAW_GITHUB + path;
+      const fileName = Utils.getFileNameFromUrl( url );
+      let fileContent = null;
+
+      try {
           fileContent = await httpClient.getAsync( url, false );
 
           if ( fileContent === '404: Not Found\n' ) {
             let urlArr = new URL( url ).pathname.split( '/' );
             urlArr.splice( 3, 0, 'master' );
-            url = HOST_RAW_GITHUB + urlArr.join( '/' ).substring(1);
+            url = HOST_RAW_GITHUB + urlArr.join( '/' );
 
             try {
               fileContent = await httpClient.getAsync( url, false );
@@ -94,8 +96,6 @@ module.exports = {
 
           reject( e );
         }
-
-      } )();
 
     } );
   }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -7,12 +7,30 @@ const each = require( '../node_modules/neo-async' ).each;
 const style = require( './consoleStyling' );
 
 const utils = {
-  readDir: ( path, callback ) => {
-    fs.readdir( path, 'utf8', ( err, files ) => {
-      if ( err )
-        callback( err, null );
-      else
-        callback( null, files );
+  /**
+   * @param { string } path The directory path.
+   * @param { Function } Callback Optional. (err, files[])
+   * 
+   * @returns { Promise<string[] | Error> }
+   */
+  readDir: ( path, Callback ) => {
+    return new Promise( ( resolve, reject ) => {
+
+      fs.readdir( path, 'utf8', ( err, files ) => {
+        if ( err ) {
+          if ( Callback )
+            return Callback( err, null );
+
+          return reject( err );
+
+        } else {
+          if (Callback)
+            return Callback( null, files );
+
+          return resolve( files );
+        }
+      } );
+
     } );
   },
 
@@ -35,13 +53,13 @@ const utils = {
       fs.readFile( configFilePath, 'utf8', ( err, data ) => {
         if ( err ) return Callback( err, null, null );
 
-        Callback( null, configFilePath, data );
+        return Callback( null, configFilePath, data );
       } );
     } );
   },
 
   /**
-   * @param { string } importFile The import file line input (from the user header/source file).
+   * @param { string } importStatement The import file line input (from the user header/source file).
    * @returns { string } The cleaned file name.
    */
   cleanImportFileInput: ( importStatement ) => {
@@ -49,7 +67,7 @@ const utils = {
   },
 
   removeImportFromInput: ( importStatement ) => {
-    return importStatement.replace( /\/@import|\/\/@|\/\/\$import|\/\/$|\/\/\%import|\/\/%/g, '' );
+    return importStatement.replace( /\/\/@import|\/\/@|\/\/\$import|\/\/$|\/\/\%import|\/\/%/g, '' );
   },
 
   /**
@@ -66,7 +84,7 @@ const utils = {
    * From the current directory ( process.cwd() ), it searches for and returns the path of the requested file or directory, false if the file was not found or an error.
    * 
    * @param { string } fileOrDir The name of the file or directory to find.
-   * @param { Function } Callback A callback (error, <string | false>) that receives the complete file/directory path or false if not found.
+   * @param { Function } Callback Optional. Callback (error, <string | false>) that receives the complete file/directory path or false if not found.
    * 
    * @returns { Promise<string | false | Error> }
    */
@@ -78,7 +96,7 @@ const utils = {
       if ( Callback )
         return Callback( err, false );
 
-      reject( err );
+      return reject( err );
     };
 
     return new Promise( ( resolve, reject ) => {
@@ -146,7 +164,7 @@ const utils = {
 
   /**
    * @param { string } path
-   * @param { Function } Callback (err, <boolean>)
+   * @param { Function } Callback Optional. (err, <boolean>)
    * 
    * @returns { Promise<boolean | Error> }
    */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merger-js",
   "displayName": "MergerJS",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Yet another light weight and simple cross-platform build tool for JavaScript files, with CLI tooling, file imports, auto build capabilities and native OS notifications.",
   "readme": "https://github.com/joao-neves95/merger-js/blob/master/README.md",
   "main": "merger.js",


### PR DESCRIPTION
 - **Added support for importing entie directories. Using this methods, the files are not compiled in any specific order**;

 - Fixed a bug introduced in v3.5.0 (commit: https://github.com/joao-neves95/merger-js/commit/a976bd6bf1ea317f344bcead2d991532a2db9684#diff-e8f6b017cf5303324df391ba7f9e0b07), in the auto build 'chnage' event async Callback (called multiple times);

 - Fixed a bug in the github imports. Starting the path of the github repository with a bar broke the fileDownloader.js ('/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js' vs. 'twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js');

 - Minor optimization and fixes on the parseImports.js module.