### PR TITLE
Update v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 &nbsp;
 
-#### *v3.7.1 - 04/05/2019
+#### *v3.8.0 - /05/2019
+
+  - Added support for importing an entire directory from GitHub.<br/>
+    There is a new import sintax for GitHub now.
+    The previous one is still supported to avoid breaking changes, but should be considered as deprecated.<br/>
+    E.g.: `// %%import<<GH::master<<dir 'twbs/bootstrap/dist/js'`<br/>
+    (Read the README.md for more information).
+  - Other minor fixes.
+  - Multiple big internal refactorings.
+
+&nbsp;
+
+#### v3.7.1 - 04/05/2019
 
  - Fixed a bug when importing from directories. It was importing relative to the header file instead of the directory of the 
    header file, like it used to (bug from last update).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 &nbsp;
 
-#### *v3.8.0 - /05/2019
+#### *v3.8.0 - 10/05/2019
 
   - Added support for importing an entire directory from GitHub.<br/>
-    There is a new import sintax for GitHub now.
+    There is a new import syntax for GitHub now.
     The previous one is still supported to avoid breaking changes, but should be considered as deprecated.<br/>
-    E.g.: `// %%import<<GH::master<<dir 'twbs/bootstrap/dist/js'`<br/>
+    New syntax: `// %%import<<GH::master<<dir 'twbs/bootstrap/dist/js'`<br/>
     (Read the README.md for more information).
-  - Other minor fixes.
   - Multiple big internal refactorings.
+  - Other minor fixes.
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 [![LICENSE](https://img.shields.io/npm/l/merger-js.svg)](https://github.com/joao-neves95/merger-js/blob/master/LICENSE)<br/>
 [![GitHub stars](https://img.shields.io/github/stars/joao-neves95/merger-js.svg?label=star&style=social)](https://github.com/joao-neves95/merger-js)
 
- Yet another lightweight and simple cross-platform CLI build tool to bundle JavaScript files, with file imports, ES6+ minification, auto build capabilities, and native OS notifications. 
+ Yet another simple cross-platform CLI build tool to bundle JavaScript files, with a custom file import syntax, ES6+ minification, auto build capabilities, and native OS notifications. 
  
  Because merger uses uglify-es for minification, you don't need to use any kind of transpilers in order to use this tool. You can use ES6+.
  
- **MergerJS *does not* support circular dependencies**
+ **MergerJS *is not* a module bundler, is a file bundler.**
  
  **NPM:** [LINK](https://www.npmjs.com/package/merger-js)<br/>
  **GitHub:** [LINK](https://github.com/joao-neves95/merger-js)<br/>
  **License:** [MIT](https://github.com/joao-neves95/merger-js/blob/master/LICENSE)<br/>
+ **Changelog:** [LINK](https://github.com/joao-neves95/merger-js/blob/master/CHANGELOG.md)<br/>
  **Dependencies:**<br/>
  ├── [uglify-es](https://www.npmjs.com/package/uglify-es)<br/>
  ├── [neo-async](https://github.com/suguru03/neo-async)<br/>
@@ -31,14 +32,14 @@
 <br/>
 
 ## Features
- - [x] **CLI tooling**
+ - [x] **Command Line Interface (CLI)**
  - [x] **Merge multiple JS files into one**
- - [x] **Support for multiple source/build files**
+ - [x] **Support for multiple source/header files**
  - [x] **Use @import comments on a source file to specify the build order**
  - [x] **Minification, supporting ES6+** (optional)
- - [x] **Auto builds on files changes** (optional)
+ - [x] **Auto builds on file changes** (optional)
  - [x] **Native OS build notifications** (optional)
- - [x] **Import a directory** (use ```@import<<DIR 'directoryName/'```)
+ - [x] **Import an entire directory** (use ```@import<<DIR 'directoryName/'```)
  - [x] **Import a file or directory from the node_modules folder** (use ```$import 'file-name'```)
  - [x] **Import a file from an URL** (use ```%import 'url'```)
  - [x] **Import a file or directory from a GitHub repository** (use ```%import<<github '<userName>/<repositoryName>/<pathToFile>.js'```)
@@ -73,7 +74,9 @@ npm install merger-js -g
 
 ## Use:
 
-1) Make a header file - the source file; the first file to be merged - containing, on the top, comments importing the files in the order you want them to be built, from the first to the last just like in a browser.<br/>
+1) Make a header file - the source file; the first file to be merged - containing, on the top,
+   comments importing the files in the order you want them to be built, from the first to the
+   last just like in a browser.<br/>
    
    Example:
    ```
@@ -101,8 +104,9 @@ npm install merger-js -g
 &nbsp;
 
 2) Run ```merger init``` on the root of your project:<br/>
-  This will set up the configuration model as well as some global configurations (minification, auto builds on file changes, native OS notifications).<br/>
-  You can alter them later through the CLI with the "merger set" command (learn more below in the "Commands" section).
+   This will set up the configuration model as well as some global configurations (minification, auto builds on file changes,
+   native OS notifications).<br/>
+   You can alter them later through the CLI with the "merger set" command (learn more below in the "Commands" section).
 
 &nbsp;
 
@@ -142,7 +146,7 @@ npm install merger-js -g
 
     * You can specify the branch using the `::` token.
 
-    * MergerJS still supports the previous GitHub import sintax for files, where the branch is specified directly on the path (not supported on directories). This sintax is deprecated.<br/>
+    * MergerJS still supports the previous GitHub import syntax for files, where the branch is specified directly on the path (not supported on directories). This syntax is deprecated.<br/>
       E.g.: `// %<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'`
 
     * Pushing (`<<`) `dir`, `DIR`, `directory` or `DIRECTORY` into `%import<<github`, imports an entire directory from GitHub.<br/>
@@ -240,11 +244,14 @@ Merger uses [SemVer](https://semver.org/) for versioning. You can read the chang
 
 **JavaScript Standard Style, *with semicolons*.**
 
-Since version 3.6.5, every asynchronous function should make exclusive use of promises with the async/await syntax, avoiding multiple callback chaining, unless using a callback instead of a promise does make sense and does not contribute to a more confusing code.
+Since version 3.6.5, every asynchronous function should make exclusive use of promises and the async/await syntax,
+avoiding multiple callback chaining (I.e.: "callback hell"), unless using a callback instead of a promise does make 
+sense and does not contribute to a more confusing code.
 
 &nbsp;
 
 ## Motivation
 
-When I started doing academic web projects, I felt the need for a build tool to merge all my JS files into one, cleaning the HTML pages and optimizing my workflow.<br/>
+When I started doing academic web projects, I felt the need for a build tool to merge all my JS files into one,
+cleaning the HTML pages and optimizing my workflow.<br/>
 I wanted something simple and fast, so I built MergerJS to use in my small web-app projects.

--- a/README.md
+++ b/README.md
@@ -131,13 +131,20 @@ npm install merger-js -g
 - ```// %import 'https://specificUrl.com/file.min.js'``` or ```// %'https://specificUrl.com/file.min.js'```:<br/>
   Using a ```%``` token imports a file from a specific URL. The file is downloaded and stored in node_modules in the first time and later fetch from there in order to not download the file in each build.<br/>
 
-  * Adding a double ```%%``` token forces the download on every build (good for updates);<br/>
+  * Adding a double ```%%``` token forces the download on every build (good for updates). Valid for specific URLs and GitHub.<br/>
     E.g.: ```// %%'/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'```<br/>
 
   * Pushing (```<<```) ```GH```, ```gh```, ```github``` or ```GITHUB``` into ```%import```, imports a file from a GitHub repository.<br/>
   If the branch name is not provided, it defaults to the "master" branch.<br/>
-    E.g.: ```// %import<<GH '<userName>/<repositoryName>/<branchName>/<pathToFile>.js'```<br/>
-          ```// %<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'```
+    E.g.:<br>
+    `// %import<<GH::{branch} '{user}/{repository}/{pathToFile}.js'`<br/>
+    `// %<<github::v4-dev '/twbs/bootstrap/dist/js/bootstrap.min.js'`
+
+    * You can specify the branch using the `::` token.
+
+    * MergerJS still supports the previous GitHub import sintax for file, where the branch is specified directly on the path (not supported on directories). This sintax is deprecated.
+      E.g.: ```// %<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'```<br/>
+
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ npm install merger-js -g
 
     * You can specify the branch using the `::` token.
 
-    * MergerJS still supports the previous GitHub import syntax for files, where the branch is specified directly on the path (not supported on directories). This syntax is deprecated.<br/>
+    * MergerJS still supports the previous GitHub import syntax for files, where the branch is specified directly on the path, to avoid breaking changes (not supported on directories). This syntax should be considered as deprecated.<br/>
       E.g.: `// %<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'`
 
     * Pushing (`<<`) `dir`, `DIR`, `directory` or `DIRECTORY` into `%import<<github`, imports an entire directory from GitHub.<br/>

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@
  - [x] **Auto builds on files changes** (optional)
  - [x] **Native OS build notifications** (optional)
  - [x] **Import a directory** (use ```@import<<DIR 'directoryName/'```)
- - [x] **Import a file from the node_modules folder** (use ```$import 'file-name'```)
+ - [x] **Import a file or directory from the node_modules folder** (use ```$import 'file-name'```)
  - [x] **Import a file from an URL** (use ```%import 'url'```)
- - [x] **Import a file from a GitHub repository** (use ```%import<<github '<userName>/<repositoryName>/<branchName>/<pathToFile>.js'```)
+ - [x] **Import a file or directory from a GitHub repository** (use ```%import<<github '<userName>/<repositoryName>/<pathToFile>.js'```)
  
 &nbsp;
 
@@ -117,15 +117,15 @@ npm install merger-js -g
 - ```// @import 'relativePathToTheFile'``` or ```// @'relativePathToTheFile'```:<br/>
    Using an ```@``` token on an import statement imports a file relative to the header file.<br/>
 
-  * Pushing (```<<```) ```dir```, ```DIR```, ```directory``` or ```DIRECTORY``` into ```@import```, imports an entire directory. 
-    Using this method, the files are not compiled in any specific order.<br/>
+  * Pushing (```<<```) ```dir```, ```DIR```, ```directory``` or ```DIRECTORY``` into ```@import```, imports an entire directory.<br/>
+    Note that using this method, the files are not compiled in any specific order.<br/>
     E.g.: ``` // @import<<dir '../otherDirectory/'``` ```// @<<DIR 'someDirectoryHere/'```
 
 - ```// $import 'pathRelativeToNodeModules'``` or ```// $'node_modules_file'```:<br/>
    Using a ```$``` token imports relative to the "node_modules" directory.
 
-  * Pushing (```<<```) ```dir```, ```DIR```, ```directory``` or ```DIRECTORY``` into ```$import```, imports an entire directory from node_modules. 
-    Using this method, the files are not compiled in any specific order.<br/>
+  * Pushing (```<<```) ```dir```, ```DIR```, ```directory``` or ```DIRECTORY``` into ```$import```, imports an entire directory from node_modules.<br/>
+    Note that using this method, the files are not compiled in any specific order.<br/>
     E.g.: ``` // $import<<dir '../otherDirectory/'``` ```// $<<DIR 'someDirectoryHere/'```
 
 - ```// %import 'https://specificUrl.com/file.min.js'``` or ```// %'https://specificUrl.com/file.min.js'```:<br/>
@@ -134,16 +134,20 @@ npm install merger-js -g
   * Adding a double ```%%``` token forces the download on every build (good for updates). Valid for specific URLs and GitHub.<br/>
     E.g.: ```// %%'/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'```<br/>
 
-  * Pushing (```<<```) ```GH```, ```gh```, ```github``` or ```GITHUB``` into ```%import```, imports a file from a GitHub repository.<br/>
-  If the branch name is not provided, it defaults to the "master" branch.<br/>
+  * Pushing (`<<`) `GH`, `gh`, `github` or `GITHUB` into `%import`, imports a file from a GitHub repository.<br/>
+  If the branch name is not provided, it is defaulted to the "master" branch.<br/>
     E.g.:<br>
     `// %import<<GH::{branch} '{user}/{repository}/{pathToFile}.js'`<br/>
     `// %<<github::v4-dev '/twbs/bootstrap/dist/js/bootstrap.min.js'`
 
     * You can specify the branch using the `::` token.
 
-    * MergerJS still supports the previous GitHub import sintax for file, where the branch is specified directly on the path (not supported on directories). This sintax is deprecated.
-      E.g.: ```// %<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'```<br/>
+    * MergerJS still supports the previous GitHub import sintax for files, where the branch is specified directly on the path (not supported on directories). This sintax is deprecated.<br/>
+      E.g.: `// %<<github '/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js'`
+
+    * Pushing (`<<`) `dir`, `DIR`, `directory` or `DIRECTORY` into `%import<<github`, imports an entire directory from GitHub.<br/>
+      Note that using this method, the files are not compiled in any specific order.<br/> 
+      E.g.: `// %%import<<GH::master<<dir 'twbs/bootstrap/dist/js'`
 
 
 &nbsp;

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,7 @@
 
 - Add optional custom source file configuration that overwrites the global merger configuration (minfication, etc.);
 
-- When checking if a file already exists before downloading it, check its contents to see if it's '404: Not Found\n'. If it is download it again;
-
 - Add an edit source file command to the CLI;
-
-- Clean up the fileDownloader module (BIG refactoring; need to also redo the entire httpClient module);
 
 - Add support for importing files with imports (big one);
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,3 +1,3 @@
 ﻿# Current Branch Version
 
-**3.8.0-dev**
+**3.8.0-beta.1**

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,3 +1,3 @@
 ﻿# Current Branch Version
 
-**3.8.0-beta.1**
+**v3.8.0**

--- a/modules/buildModules/parseImports.js
+++ b/modules/buildModules/parseImports.js
@@ -91,7 +91,7 @@ module.exports = ( Path, Callback ) => {
       try {
         const createdNodeModules = await Utils.createNodeModulesIfNeeded();
         if ( createdNodeModules ) {
-          NODE_MODULES_PATH = global.config.nodeModulesPath
+          NODE_MODULES_PATH = global.config.nodeModulesPath;
           await addPropertyToConfig( ConfigKeysType.nodeModulesPath, NODE_MODULES_PATH );
         }
 

--- a/modules/buildModules/parseImports.js
+++ b/modules/buildModules/parseImports.js
@@ -103,14 +103,14 @@ module.exports = ( Path, Callback ) => {
       // // %import<<GH::{branch} '{user}/{repo}/{pathToFile}.js'
       // // %import<<GH::{branch}<<DIR '{user}/{repo}/{pathToFile}.js'
       // // %import<<GH::master<<DIR '{user}/{repo}/{pathToFile}.js'
-      // DEPRECATED SINTAX: // %import<<GH '{user}/{repo}/{branch}/{pathToFile}.js'
+      // DEPRECATED syntax: // %import<<GH '{user}/{repo}/{branch}/{pathToFile}.js'
       if ( treatedLine.startsWith( '<<gh' ) ||
            treatedLine.startsWith( '<<GH' ) ||
            treatedLine.startsWith( '<<github' ) ||
            treatedLine.startsWith( '<<GITHUB' ) )
       {
         treatedLine = Utils.removeGithubTokenFromImport( treatedLine );
-        let isNewSintax = false;
+        let isNewSyntax = false;
         let branch = '';
         if ( treatedLine.startsWith( '::' ) ) {
           treatedLine = treatedLine.replace( /::/g, '' );
@@ -122,7 +122,7 @@ module.exports = ( Path, Callback ) => {
             branch += treatedLine[i];
           }
 
-          isNewSintax = true;
+          isNewSyntax = true;
           treatedLine = treatedLine.substring( branch.length );
         }
 
@@ -146,7 +146,7 @@ module.exports = ( Path, Callback ) => {
         const thisRepoDirPath = path.join( NODE_MODULES_PATH, thisRepoDirName );
 
         //#region FROM A GITHUB DIRECTORY.
-        // (using exclusively the new sintax)
+        // (using exclusively the new syntax)
         // TODO: (FIX) GITHUB DIRECTORY IMPORTS NOT WORKING.
         if ( isDir ) {
           const thisRepoDirDirPath = path.join( thisRepoDirPath, inputedPathToFile );
@@ -180,30 +180,30 @@ module.exports = ( Path, Callback ) => {
         //#endregion
 
         //#region FROM A GIRHUB FILE.
-        // (using the new sintax, but supporting the deprecated method and sintax)
-        // TODO: Remove support for the deprecated sintax on v4, if there is one.
+        // (using the new syntax, but supporting the deprecated syntax)
+        // TODO: Remove support for the deprecated syntax on v4, if there is one.
         } else {
           const fileName = path.basename( treatedLine );
-          let alreadyDownloadedPreviousSintax = false;
-          let alreadyDownloadedNewSintax = false;
+          let alreadyDownloadedPreviousSyntax = false;
+          let alreadyDownloadedNewSyntax = false;
 
-          if ( !forceInstall && !isNewSintax ) {
-            // No need to check with the previous sintax.
-            alreadyDownloadedPreviousSintax = await Utils.fileExists( path.join( NODE_MODULES_PATH, fileName ) );
+          if ( !forceInstall && !isNewSyntax ) {
+            // No need to check with the previous syntax.
+            alreadyDownloadedPreviousSyntax = await Utils.fileExists( path.join( NODE_MODULES_PATH, fileName ) );
 
-          } else if ( !forceInstall && isNewSintax ) {
-            alreadyDownloadedNewSintax = await Utils.fileExists( path.join( thisRepoDirPath, inputedPathToFile ) );
+          } else if ( !forceInstall && isNewSyntax ) {
+            alreadyDownloadedNewSyntax = await Utils.fileExists( path.join( thisRepoDirPath, inputedPathToFile ) );
           }
 
-          if ( ( isNewSintax && !alreadyDownloadedNewSintax ) || ( isNewSintax && forceInstall ) ) {
+          if ( ( isNewSyntax && !alreadyDownloadedNewSyntax ) || ( isNewSyntax && forceInstall ) ) {
             await fileDownloader.fromGithub( githubPath[0], githubPath[1], inputedPathToFile, branch === '' ? 'master' : branch );
 
-          } else if ( ( !isNewSintax && !alreadyDownloadedPreviousSintax ) || ( !isNewSintax && forceInstall ) ) {
+          } else if ( ( !isNewSyntax && !alreadyDownloadedPreviousSyntax ) || ( !isNewSyntax && forceInstall ) ) {
             // use the deprecated method. 
             await fileDownloader.fromGitHub_deprecated( treatedLine, branch );
           }
 
-          thisFile = isNewSintax ? path.join( thisRepoDirPath, inputedPathToFile ) :
+          thisFile = isNewSyntax ? path.join( thisRepoDirPath, inputedPathToFile ) :
             path.join( NODE_MODULES_PATH, fileName );
         }
         //#endregion

--- a/modules/fileDownloader.js
+++ b/modules/fileDownloader.js
@@ -85,7 +85,7 @@ class FileDownloader {
             fileContent = await httpClient.getAsync( url, false );
 
             if ( fileContent.statusCode !== 200 )
-              FileDownloader.githubDownloadError( new URL( url ).pathname, e );
+              FileDownloader.githubDownloadError( new URL( url ).pathname );
 
           } catch ( e ) {
             FileDownloader.githubDownloadError( new URL( url ).pathname, e );

--- a/modules/fileDownloader.js
+++ b/modules/fileDownloader.js
@@ -44,10 +44,10 @@ class FileDownloader {
   }
 
 
-  // DEPRECATED SINTAX: // %import<<GH '{user}/{repo}/{branch}/{pathToFile}.js'
+  // DEPRECATED syntax: // %import<<GH '{user}/{repo}/{branch}/{pathToFile}.js'
   // https://raw.githubusercontent.com/{user}/{repo}/{brach}/{pathToFle}.js
   /**
-   * [DEPRECATED, used for the previous sintax]
+   * [DEPRECATED, used for the previous syntax]
    * Downloads a file from GitHub and saves it to node_modules. Returns the file name or an error.
    * 
    * @param { string } path <userName>/<repositoryName>/(<branchName>)/<pathToFile>
@@ -175,7 +175,7 @@ class FileDownloader {
   static githubDownloadError( filePath, exception ) {
     console.error(
       style.styledError,
-      `There was an error while downloading a file from GitHub ("${filePath}"):\nPlease, check the import sintax again.\n\n`,
+      `There was an error while downloading a file from GitHub ("${filePath}"):\nPlease, check the import syntax again.\n\n`,
       exception
     );
 

--- a/modules/httpClient.js
+++ b/modules/httpClient.js
@@ -8,6 +8,7 @@
 
 'use strict';
 const https = require( 'https' );
+const { IncomingMessage } = require( 'http' );
 
 /**
  * Allways HTTPS.
@@ -15,24 +16,24 @@ const https = require( 'https' );
 module.exports = {
   /**
    * Get HTTPS async.
+   * It returns a Response object with the data in Response.body.
    * 
    * @param { string } url
    * @param { boolean } parseJson Defaults to true. Whether to parse the JSON before return.
    * @param { Function } Callback Optional callback that receives (error, data).
    * 
-   * @returns { Promise<string | Error> }
+   * @returns { Promise<IncomingMessage | Error> }
    */
-  getAsync: ( url, parseJson = true, Callback ) => {
+  getAsync: ( url, Callback ) => {
     return new Promise( ( resolve, reject ) => {
 
       try {
-        https.get( url, ( res ) => {
+        https.get( url, { headers: { "User-Agent": `MergerJS/${global.version}` } }, ( res ) => {
           res.setEncoding( 'utf8' );
-
-          let allData = '';
+          res.body = '';
 
           res.on( 'data', ( resData ) => {
-            allData += resData;
+            res.body += resData;
           } );
 
           res.on( 'error', ( err ) => {
@@ -43,14 +44,10 @@ module.exports = {
           } );
 
           res.on( 'end', () => {
-            if ( parseJson )
-              allData = JSON.parse( allData );
-
             if ( Callback )
-              return Callback( null, allData );
+              return Callback( null, res );
 
-            resolve( allData );
-
+            resolve( res );
           } );
         } );
 

--- a/modules/httpClient.js
+++ b/modules/httpClient.js
@@ -19,7 +19,6 @@ module.exports = {
    * It returns a Response object with the data in Response.body.
    * 
    * @param { string } url
-   * @param { boolean } parseJson Defaults to true. Whether to parse the JSON before return.
    * @param { Function } Callback Optional callback that receives (error, data).
    * 
    * @returns { Promise<IncomingMessage | Error> }

--- a/modules/mergerCLI.js
+++ b/modules/mergerCLI.js
@@ -18,9 +18,9 @@ const selectSourceFile = require( './CLIModules/selectSourceFilePrompt' );
 const EditConfigFile = require( './CLIModules/editConfigFile' );
 const style = require('./consoleStyling');
 const ConfigKeysType = require('../models/configKeysEnum');
-global.version = require('../package.json').version;
 
 module.exports = ( Callback ) => {
+  global.version = require('../package.json').version;
   global.config = {};
   let newConfig = {};
 

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -45,6 +45,29 @@ class Utils {
     } );
   }
 
+  /**
+   * Creates a new directory.
+   * Returns a promise with a boolean stating whether the file was created or not, or an Error.
+   * 
+   * @param { string } path
+   * 
+   * @returns { Promise<boolean | Error> }
+   */
+  static mkdir( path ) {
+    return new Promise( ( _res, _rej ) => {
+      fs.mkdir( path, ( err ) => {
+        if ( err ) {
+          if ( err.code !== 'EEXIST' )
+            return _rej( err );
+
+          return _res( false );
+        }
+
+        return _res( true );
+      } );
+    } );
+  }
+
   static writeJSONFile( dir, fileName, data, callback ) {
     let jsonData = JSON.stringify( data, null, '\t' );
 
@@ -80,6 +103,10 @@ class Utils {
     return importStatement.replace( /\/\/|@import|@|\$import|\$|\%import|\%|\%%import|\%\%/g, '' );
   }
 
+  static removeDirTokenFromImport( importStatement ) {
+    return importStatement.replace( /<<dir|<<DIR|<<directory|<<DIRECTORY/g, '' );
+  }
+
   /**
    * @param { string } url
    * 
@@ -88,6 +115,21 @@ class Utils {
   static getFileNameFromUrl( url ) {
     const fileNameArr = new URL( url ).pathname.split( '/' );
     return fileNameArr[fileNameArr.length - 1];
+  }
+
+  /**
+   * Get the extension name of a file.
+   * Same as Nodejs.path.extname( path )
+   * 
+   * @param { string } path
+   * @returns { string }
+   */
+  static fileExt( path ) {
+    return path.extname( path );
+  }
+
+  static buildGithubRepoDirName( user, repo ) {
+    return `${user}@${repo}`;
   }
 
   /**
@@ -199,6 +241,19 @@ class Utils {
           return Callback( null, true );
 
         return resolve( true );
+      } );
+
+    } );
+  }
+
+  static dirExists( thePath ) {
+    return new Promise( ( _res, _rej ) => {
+
+      fs.stat( path.normalize( thePath ), ( err, stats ) => {
+        if ( err )
+          return _res( false );
+
+        return _res( stats.isDirectory() );
       } );
 
     } );

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -103,6 +103,10 @@ class Utils {
     return importStatement.replace( /\/\/|@import|@|\$import|\$|\%import|\%|\%%import|\%\%/g, '' );
   }
 
+  static removeGithubTokenFromImport( importStatement ) {
+    return importStatement.replace( /<<gh|<<GH|<<github|<<GITHUB/g, '' );
+  }
+
   static removeDirTokenFromImport( importStatement ) {
     return importStatement.replace( /<<dir|<<DIR|<<directory|<<DIRECTORY/g, '' );
   }
@@ -124,8 +128,8 @@ class Utils {
    * @param { string } path
    * @returns { string }
    */
-  static fileExt( path ) {
-    return path.extname( path );
+  static fileExt( inputPath ) {
+    return path.extname( inputPath );
   }
 
   static buildGithubRepoDirName( user, repo ) {
@@ -266,10 +270,15 @@ class Utils {
    * 
    * @returns { Promise<void | Error> }
    */
-  static saveFileInNodeModules( fileName, data, Callback ) {
-    return new Promise( ( resolve, reject ) => {
+  static async saveFileInNodeModules( fileName, data, Callback ) {
+    return new Promise( async ( resolve, reject ) => {
 
-      fs.writeFile( path.join( global.config.nodeModulesPath, fileName ), data, 'utf8', ( err ) => {
+      const thisDirName = path.dirname( path.join( global.config.nodeModulesPath, fileName ) );
+      const dirExists = await Utils.dirExists( thisDirName );
+      if ( !dirExists )
+        await Utils.mkdir( thisDirName );
+
+      fs.writeFile( path.join( thisDirName, path.basename( fileName ) ), data, 'utf8', ( err ) => {
 
         if ( err ) {
           if ( Callback )

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2018-2019 João Pedro Martins Neves - All Rights Reserved.
  *
  * MergerJS (merger-js) is licensed under the MIT license, located in
@@ -50,12 +50,13 @@ class Utils {
    * Returns a promise with a boolean stating whether the file was created or not, or an Error.
    * 
    * @param { string } path
+   * @param { boolean } doItRecursive
    * 
    * @returns { Promise<boolean | Error> }
    */
-  static mkdir( path ) {
+  static mkdir( path, doItRecursive = true ) {
     return new Promise( ( _res, _rej ) => {
-      fs.mkdir( path, ( err ) => {
+      fs.mkdir( path, { recursive: doItRecursive }, ( err ) => {
         if ( err ) {
           if ( err.code !== 'EEXIST' )
             return _rej( err );
@@ -252,14 +253,18 @@ class Utils {
 
   static dirExists( thePath ) {
     return new Promise( ( _res, _rej ) => {
+      try {
 
-      fs.stat( path.normalize( thePath ), ( err, stats ) => {
-        if ( err )
-          return _res( false );
+        fs.stat( path.normalize( thePath ), ( err, stats ) => {
+          if ( err )
+            return _res( false );
 
-        return _res( stats.isDirectory() );
-      } );
+          return _res( stats.isDirectory() );
+        } );
 
+      } catch ( e ) {
+        return _res( false );
+      }
     } );
   }
 
@@ -279,7 +284,6 @@ class Utils {
         await Utils.mkdir( thisDirName );
 
       fs.writeFile( path.join( thisDirName, path.basename( fileName ) ), data, 'utf8', ( err ) => {
-
         if ( err ) {
           if ( Callback )
             return Callback( err );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merger-js",
   "displayName": "MergerJS",
-  "version": "3.8.0-beta.1",
+  "version": "3.8.0",
   "description": "Yet another lightweight and simple cross-platform CLI build tool to bundle JavaScript files, with file imports, ES6+ minification, auto build capabilities, and native OS notifications.",
   "readme": "https://github.com/joao-neves95/merger-js/blob/master/README.md",
   "main": "merger.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merger-js",
   "displayName": "MergerJS",
-  "version": "3.7.1",
+  "version": "3.8.0-beta.1",
   "description": "Yet another lightweight and simple cross-platform CLI build tool to bundle JavaScript files, with file imports, ES6+ minification, auto build capabilities, and native OS notifications.",
   "readme": "https://github.com/joao-neves95/merger-js/blob/master/README.md",
   "main": "merger.js",


### PR DESCRIPTION
- Added support for importing an entire directory from GitHub.

- There is a new import syntax for GitHub now.
  The previous one is still supported to avoid breaking changes, but should be 
  considered as deprecated.
  New syntax: `// %import<<GH::master<<dir 'twbs/bootstrap/dist/js'`.
  (Read the README.md for more information).

- Multiple big internal refactorings.

- Other minor fixes.
